### PR TITLE
Use Cypress v11.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,9 +397,9 @@
       }
     },
     "cypress": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.6.0.tgz",
-      "integrity": "sha512-WdHSVaS1lumSd5XpVTslZd8ui9GIGphrzvXq9+3DtVhqjRZC5M70gu5SW/Y/SLPq3D1wiXGZoHC6HJ7ESVE2lw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -419,7 +419,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.2",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "cypress:run": "cypress run"
   },
   "devDependencies": {
-    "cypress": "12.6.0"
+    "cypress": "11.2.0"
   }
 }


### PR DESCRIPTION
This branch passes Cypress as v11.2.0 didn't suffer from this issue.

## Video from Chrome test run

https://user-images.githubusercontent.com/482561/219787439-bbab9cbc-dd43-49b1-8f31-ba5eb161fa7b.mp4

