### PR TITLE
Workaround idea: Clear cookies in an intercepted request

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -6,6 +6,19 @@ describe('issue https://github.com/cypress-io/cypress/issues/25841 reproduction'
     cy.contains('FLASH_FROM_REDIRECT_ACTION').should('be.visible')
     cy.visit('/page_b')
     cy.contains('THIS_SHOULD_BE_VISIBLE_AFTER_BUTTON_CLICK').should('not.exist')
+
+    // Workaround odea by @ksazhnev
+    // https://github.com/cypress-io/cypress/issues/25841#issuecomment-1807468630
+    //
+    // However, this requires clicking the button twice.
+    cy.intercept('POST', '/set_the_flash').as('firstRequest')
+    cy.contains('Trigger fetch request').click()
+    cy.wait('@firstRequest').then((interception) => {
+      // Delete all cookies after sending the request
+      cy.clearCookies();
+    })
+    // --- end of workaround.
+
     cy.contains('Trigger fetch request').click()
     cy.contains('THIS_SHOULD_BE_VISIBLE_AFTER_BUTTON_CLICK').should('be.visible')
   })


### PR DESCRIPTION
This PR shows the workaround by @ksazhnev in this reproduction repository

> https://github.com/cypress-io/cypress/issues/25841#issuecomment-1807468630
>
> In our case, after the button is clicked, there are two consecutive requests. The first request will respond with a new cookie value, set-cookie, and then the new cookie value will be used in the second request. When seeing the networking tab in dev tools, the browser displays the correct cookies to be sent; however, with debug in Cypress, it does send the old cookies from the cookie jar. I found a temporary workaround in our case, which is deleting cookies after sending the first request and before getting the response with a new cookie value. In this case, Cypress is using cookies from the request header since the jar is empty. I still wonder what the method that updates or syncs the cookie jar value in the Cypress code since the browser cookie jar is correct.
> 
> Here the temporary workaround I am currently using: `cy.intercept('POST', 'endpoint').as('firstRequest'); cy.get('body').find('button[type="button"]').contains('login').click(); cy.wait('@firstRequest').then((interception) => { // Delete all cookies after sending the request cy.clearCookies(); });` @valscion

However, the workaround seems to require clicking the button triggering the fetch request twice so it is not a satisfiable workaround.
